### PR TITLE
Add feature tests for change password page

### DIFF
--- a/tests/Feature/ChangePassFeatureTest.php
+++ b/tests/Feature/ChangePassFeatureTest.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class ChangePasswordFeatureTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->startSession();
+    }
+
+    protected function createTestUser(string $password = 'password123'): User
+    {
+        return User::factory()->create([
+            'password' => bcrypt($password),
+        ]);
+    }
+
+    public function testChangePasswordPageAccessible(): void
+    {
+        $user = $this->createTestUser();
+        $this->actingAs($user)
+            ->get(route('profile.change-password'))
+            ->assertOk()
+            ->assertViewIs('profile.change-password');
+    }
+
+    public function testValidPasswordChange(): void
+    {
+        $user = $this->createTestUser('oldpassword');
+        $this->actingAs($user);
+
+        $response = $this->withHeaders(['referer' => route('profile.change-password')])
+                         ->postWithCsrf(route('profile.change-password.update'), [
+                             'current_password'      => 'oldpassword',
+                             'password'              => 'newpassword123',
+                             'password_confirmation' => 'newpassword123',
+                         ]);
+
+        $response->assertRedirect(route('profile.change-password'))
+                 ->assertSessionHas('status', 'password-updated');
+
+        $this->assertTrue(Hash::check('newpassword123', $user->fresh()->password));
+    }
+
+    public function testChangePasswordFailsWithIncorrectCurrentPassword(): void
+    {
+        $user = $this->createTestUser('oldpassword');
+        $this->actingAs($user);
+
+        $response = $this->withHeaders(['referer' => route('profile.change-password')])
+                         ->postWithCsrf(route('profile.change-password.update'), [
+                             'current_password'      => 'wrongpassword',
+                             'password'              => 'newpassword123',
+                             'password_confirmation' => 'newpassword123',
+                         ]);
+
+        $response->assertRedirect(route('profile.change-password'))
+                 ->assertSessionHasErrors(['current_password']);
+
+        $this->assertTrue(Hash::check('oldpassword', $user->fresh()->password));
+    }
+
+    public function testSqlInjectionAttemptFails(): void
+    {
+        $user = $this->createTestUser('oldpassword');
+        $this->actingAs($user);
+
+        $response = $this->withHeaders(['referer' => route('profile.change-password')])
+                         ->postWithCsrf(route('profile.change-password.update'), [
+                             'current_password'      => "' OR '1'='1",
+                             'password'              => 'newpassword123',
+                             'password_confirmation' => 'newpassword123',
+                         ]);
+
+        $response->assertRedirect(route('profile.change-password'))
+                 ->assertSessionHasErrors(['current_password']);
+
+        $this->assertTrue(Hash::check('oldpassword', $user->fresh()->password));
+    }
+
+    public function testCsrfProtection(): void
+    {
+        $user = $this->createTestUser('oldpassword');
+        $this->actingAs($user);
+
+        $response = $this->withHeaders(['referer' => route('profile.change-password')])
+                         ->post(route('profile.change-password.update'), [
+                             'current_password'      => 'oldpassword',
+                             'password'              => 'newpassword123',
+                             'password_confirmation' => 'newpassword123',
+                         ]);
+
+        $response->assertCsrfMismatch();
+        $this->assertTrue(Hash::check('oldpassword', $user->fresh()->password));
+    }
+
+    public function testPasswordConfirmationMismatch(): void
+    {
+        $user = $this->createTestUser('oldpassword');
+        $this->actingAs($user);
+
+        $response = $this->withHeaders(['referer' => route('profile.change-password')])
+                         ->postWithCsrf(route('profile.change-password.update'), [
+                             'current_password'      => 'oldpassword',
+                             'password'              => 'newpassword123',
+                             'password_confirmation' => 'differentpassword',
+                         ]);
+
+        $response->assertRedirect(route('profile.change-password'))
+                 ->assertSessionHasErrors(['password']);
+
+        $this->assertTrue(Hash::check('oldpassword', $user->fresh()->password));
+    }
+
+    public function testNewPasswordTooShort(): void
+    {
+        $user = $this->createTestUser('oldpassword');
+        $this->actingAs($user);
+
+        $response = $this->withHeaders(['referer' => route('profile.change-password')])
+                         ->postWithCsrf(route('profile.change-password.update'), [
+                             'current_password'      => 'oldpassword',
+                             'password'              => 'short',
+                             'password_confirmation' => 'short',
+                         ]);
+
+        $response->assertRedirect(route('profile.change-password'))
+                 ->assertSessionHasErrors(['password']);
+
+        $this->assertTrue(Hash::check('oldpassword', $user->fresh()->password));
+    }
+
+    public function testMissingFieldsForPasswordChange(): void
+    {
+        $user = $this->createTestUser('oldpassword');
+        $this->actingAs($user);
+
+        $response = $this->withHeaders(['referer' => route('profile.change-password')])
+                         ->postWithCsrf(route('profile.change-password.update'), [
+                             'password'              => 'newpassword123',
+                             'password_confirmation' => 'newpassword123',
+                         ]);
+        $response->assertRedirect(route('profile.change-password'))
+                 ->assertSessionHasErrors(['current_password']);
+
+        $response = $this->withHeaders(['referer' => route('profile.change-password')])
+                         ->postWithCsrf(route('profile.change-password.update'), [
+                             'current_password' => 'oldpassword',
+                         ]);
+        $response->assertRedirect(route('profile.change-password'))
+                 ->assertSessionHasErrors(['password']);
+    }
+
+    public function testSamePasswordChange(): void
+    {
+        $user = $this->createTestUser('oldpassword');
+        $this->actingAs($user);
+
+        $response = $this->withHeaders(['referer' => route('profile.change-password')])
+                         ->postWithCsrf(route('profile.change-password.update'), [
+                             'current_password'      => 'oldpassword',
+                             'password'              => 'oldpassword',
+                             'password_confirmation' => 'oldpassword',
+                         ]);
+
+        $response->assertRedirect(route('profile.change-password'))
+                 ->assertSessionHas('status', 'password-updated');
+
+        $this->assertTrue(Hash::check('oldpassword', $user->fresh()->password));
+    }
+
+    public function testEdgeCaseInputForPasswordChange(): void
+    {
+        $user = $this->createTestUser('oldpassword');
+        $this->actingAs($user);
+
+        $longPassword = str_repeat('A!a1', 50); // 200 characters long
+        $response = $this->withHeaders(['referer' => route('profile.change-password')])
+                         ->postWithCsrf(route('profile.change-password.update'), [
+                             'current_password'      => 'oldpassword',
+                             'password'              => $longPassword,
+                             'password_confirmation' => $longPassword,
+                         ]);
+
+        $response->assertRedirect(route('profile.change-password'))
+                 ->assertSessionHas('status', 'password-updated');
+        $this->assertTrue(Hash::check($longPassword, $user->fresh()->password));
+    }
+}


### PR DESCRIPTION
This PR adds new feature tests for the change password page. The tests cover a variety of scenarios such as:

    - Making sure the page loads correctly.
    - Successfully updating the password when given the correct current password.
    - Handling cases where the current password is wrong.
    - Catching issues like password confirmation mismatches and too-short new passwords.
    - Protecting against basic SQL injection attempts.
    - Testing for missing required fields.