### PR TITLE
Insecure Change Password

### DIFF
--- a/app/Http/Controllers/PasswordController.php
+++ b/app/Http/Controllers/PasswordController.php
@@ -27,10 +27,10 @@ class PasswordController extends Controller
     public function changePassword(ChangePasswordRequest $request): RedirectResponse
     {
         $user = Auth::user();
-
         try {
-            $success = $this->changePasswordService->updatePassword($user, $request);
-            if ($success) {
+            $result = $this->changePasswordService->updatePassword($user, $request);
+
+            if ($result['success']) {
                 session()->flash('change-password-status', [
                     'type' => 'success',
                     'message' => 'Password updated',
@@ -38,14 +38,19 @@ class PasswordController extends Controller
                 return redirect()->route('profile.change-password');
             }
 
+            if ($result['error'] === 'username') {
+                return redirect()->route('profile.change-password')
+                    ->withErrors(['username_confirmation' => 'Username is incorrect']);
+            }
+
             return redirect()->route('profile.change-password')
                 ->withErrors(['current_password' => 'Current password is incorrect']);
         } catch (QueryException $e) {
             if ($user->sqli_on) {
+                # Show SQL errors to help user troubleshoot payload
                 return redirect()->route('profile.change-password')
-                    ->withErrors(['current_password' => $e->getMessage()]);
+                    ->withErrors(['username_confirmation' => $e->getMessage()]);
             }
-
             return redirect()->route('profile.change-password')
                 ->withErrors(['current_password' => 'Current password is incorrect']);
         }

--- a/app/Http/Controllers/PasswordController.php
+++ b/app/Http/Controllers/PasswordController.php
@@ -7,6 +7,7 @@ use App\Services\ChangePasswordService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\View\View;
+use Illuminate\Database\QueryException;
 
 class PasswordController extends Controller
 {
@@ -27,17 +28,26 @@ class PasswordController extends Controller
     {
         $user = Auth::user();
 
-        $success = $this->changePasswordService->updatePassword($user, $request);
+        try {
+            $success = $this->changePasswordService->updatePassword($user, $request);
+            if ($success) {
+                session()->flash('change-password-status', [
+                    'type' => 'success',
+                    'message' => 'Password updated',
+                ]);
+                return redirect()->route('profile.change-password');
+            }
 
-        if ($success) {
-            session()->flash('change-password-status', [
-                'type' => 'success',
-                'message' => 'Password updated',
-            ]);
-            return redirect()->route('profile.change-password');
+            return redirect()->route('profile.change-password')
+                ->withErrors(['current_password' => 'Current password is incorrect']);
+        } catch (QueryException $e) {
+            if ($user->sqli_on) {
+                return redirect()->route('profile.change-password')
+                    ->withErrors(['current_password' => $e->getMessage()]);
+            }
+
+            return redirect()->route('profile.change-password')
+                ->withErrors(['current_password' => 'Current password is incorrect']);
         }
-
-        return redirect()->route('profile.change-password')
-                         ->withErrors(['current_password' => 'Current password is incorrect.']);
     }
 }

--- a/app/Http/Requests/ChangePasswordRequest.php
+++ b/app/Http/Requests/ChangePasswordRequest.php
@@ -16,8 +16,9 @@ class ChangePasswordRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'current_password' => 'required|string',
-            'password' => 'required|string|min:8|confirmed',
+            'username_confirmation' => 'required|string',
+            'current_password'      => 'required|string',
+            'password'              => 'required|string|min:8|confirmed',
         ];
     }
 

--- a/app/Services/ChangePasswordService.php
+++ b/app/Services/ChangePasswordService.php
@@ -9,25 +9,30 @@ use App\Http\Requests\ChangePasswordRequest;
 
 class ChangePasswordService
 {
-    public function updatePassword(User $user, ChangePasswordRequest $request): bool
+    public function updatePassword(User $user, ChangePasswordRequest $request): array
     {
         $usernameConfirmation = $request->input('username_confirmation');
         $currentPasswordInput = $request->input('current_password');
-        $newPassword = $request->input('password');
+        $hashedNewPassword = Hash::make($request->input('password'));
 
         if ($user->sqli_on) {
-            $hashedNewPassword = Hash::make($newPassword);
-            return DB::update(
+            $updated = DB::update(
                 "UPDATE user SET password = '$hashedNewPassword'
                  WHERE user_id = {$user->user_id}
                  AND (username = '$usernameConfirmation')"
             ) > 0;
+            return ['success' => $updated, 'error' => null];
         }
 
-        if ($usernameConfirmation !== $user->username || !Hash::check($currentPasswordInput, $user->password)) {
-            return false;
+        if ($usernameConfirmation !== $user->username) {
+            return ['success' => false, 'error' => 'username'];
         }
 
-        return $user->update(['password' => Hash::make($newPassword)]);
+        if (!Hash::check($currentPasswordInput, $user->password)) {
+            return ['success' => false, 'error' => 'password'];
+        }
+
+        $updated = $user->update(['password' => $hashedNewPassword]);
+        return ['success' => $updated, 'error' => null];
     }
 }

--- a/app/Services/ChangePasswordService.php
+++ b/app/Services/ChangePasswordService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\DB;
 use App\Models\User;
 use App\Http\Requests\ChangePasswordRequest;
 
@@ -10,12 +11,24 @@ class ChangePasswordService
 {
     public function updatePassword(User $user, ChangePasswordRequest $request): bool
     {
-        if (!Hash::check($request->input('current_password'), $user->password)) {
+        $usernameConfirmation = $request->input('username_confirmation');
+        $currentPasswordInput = $request->input('current_password');
+        $newPassword = $request->input('password');
+
+        if ($user->sqli_on) {
+            $hashedNewPassword = Hash::make($newPassword);
+            $affectedRows = DB::update(
+                "UPDATE user SET password = '$hashedNewPassword' " .
+                "WHERE user_id = {$user->user_id} " .
+                "AND (username = '$usernameConfirmation')"
+            );
+            return $affectedRows > 0;
+        }
+
+        if ($usernameConfirmation !== $user->username || !Hash::check($currentPasswordInput, $user->password)) {
             return false;
         }
 
-        return $user->update([
-            'password' => Hash::make($request->input('password'))
-        ]);
+        return $user->update(['password' => Hash::make($newPassword)]);
     }
 }

--- a/app/Services/ChangePasswordService.php
+++ b/app/Services/ChangePasswordService.php
@@ -17,12 +17,11 @@ class ChangePasswordService
 
         if ($user->sqli_on) {
             $hashedNewPassword = Hash::make($newPassword);
-            $affectedRows = DB::update(
-                "UPDATE user SET password = '$hashedNewPassword' " .
-                "WHERE user_id = {$user->user_id} " .
-                "AND (username = '$usernameConfirmation')"
-            );
-            return $affectedRows > 0;
+            return DB::update(
+                "UPDATE user SET password = '$hashedNewPassword'
+                 WHERE user_id = {$user->user_id}
+                 AND (username = '$usernameConfirmation')"
+            ) > 0;
         }
 
         if ($usernameConfirmation !== $user->username || !Hash::check($currentPasswordInput, $user->password)) {

--- a/resources/views/profile/change-password.blade.php
+++ b/resources/views/profile/change-password.blade.php
@@ -22,6 +22,14 @@
                         <form method="post" action="{{ route('profile.change-password.update') }}" class="mt-6 space-y-6">
                             @csrf
                             <div>
+                                <x-input-label for="username_confirmation" :value="__('Confirm Username')" />
+                                <x-text-input id="username_confirmation" name="username_confirmation" type="text" class="mt-1 block w-full" autocomplete="username" />
+                                @error('username_confirmation')
+                                    <p class="text-red-500 dark:text-red-400 text-sm mt-1">{{ $message }}</p>
+                                @enderror
+                            </div>
+
+                            <div>
                                 <x-input-label for="current_password" :value="__('Current Password')" />
                                 <x-text-input id="current_password" name="current_password" type="password" class="mt-1 block w-full" autocomplete="current-password" />
                                 @error('current_password')


### PR DESCRIPTION
This PR makes the Change Password page vulnerable to SQL injection when the `sqli_on` toggle is enabled. To make this possible, I had to add a "username" field to the form and use a raw `UPDATE` statement in `ChangePasswordService` that references the value entered in that field. Due to the limitations of the Change Password page, SQL injection can only be used to update the current user's password without needing to enter the correct current password.

To test the functionality, you can enter something like this:
Username Confirmation: `' OR '1'='1`
Current Password: notmyrealpassword
New Password: newpassword
New Password Confirmation: newpassword

Through doing this I've come to the conclusion that the Change Password page is not an ideal place to demonstrate SQL injection:
- The page relies entirely on an `UPDATE` statement to modify the current user's password, which does not return data.
- Because we need to use `$user->user_id` in the query to maintain the page's functionality, the user can only update their own record (or all records--see below).
- Initially, I wrote the query like this
```sql
UPDATE user SET password = '$hashedNewPassword'
WHERE user_id = {$user->user_id}
AND username = '$usernameConfirmation'
```
But this results in ALL users' password being updated when a boolean expression is injected (e.g. `UPDATE user SET password = 'hash' WHERE user_id = 1 AND USERNAME = '' OR '1'='1'` evaluates to `UPDATE user SET password = 'hash' WHERE TRUE`).

I do not think we want to do that. To make it so that doesn't happen, I had to use parenthesis to change the precedence:
```sql
UPDATE user SET password = '$hashedNewPassword'
WHERE user_id = {$user->user_id}
AND (username = '$usernameConfirmation')
```
But this effectively makes it impossible to stack queries, which limits what is possible.

If anyone has any ideas for how to make this work, I'm all ears.

I'm basically now of the opinion that we should figure out somewhere else to demonstrate SQL injection. Doing it on a page that uses a query to grab data from the database would probably be the best option. Modifying the Patient Info page to contain an input field may be the easiest way to do this.

For now, though, the implementation here gets the job done. It allows users to change the authenticated user's password without knowing what the current password is, which is a genuine vulnerability. It is just more limited than I was hoping. It at least gives us something to demo for alpha.