### PR TITLE
Fix File Display

### DIFF
--- a/app/Services/PatientRecordService.php
+++ b/app/Services/PatientRecordService.php
@@ -43,6 +43,7 @@ class PatientRecordService
         $safeKeyword = preg_replace('/[^a-zA-Z0-9_-]/', '', $keyword);
 
         $files = scandir($directory);
+        $files = array_diff($files, ['.', '..']);
         if (!$files) {
             return [];
         }


### PR DESCRIPTION
Gets rid of dots displaying when showcasing a user's files on the request records page (caused by the new scandir)