### PR TITLE
A few more demo setup changes

### DIFF
--- a/app/Http/Middleware/LogUserActivityMiddleware.php
+++ b/app/Http/Middleware/LogUserActivityMiddleware.php
@@ -20,6 +20,9 @@ class LogUserActivityMiddleware
     public function __invoke(Request $request, Closure $next): Response
     {
         $response = $next($request);
+        if ($request->is('health') && str_contains($request->userAgent(), 'GoogleHC')) {
+            return $response;
+        }
         app(UserActivityLogger::class)->info('User accessed route');
         return $response;
     }

--- a/app/Http/Middleware/LogUserActivityMiddleware.php
+++ b/app/Http/Middleware/LogUserActivityMiddleware.php
@@ -20,10 +20,20 @@ class LogUserActivityMiddleware
     public function __invoke(Request $request, Closure $next): Response
     {
         $response = $next($request);
-        if ($request->is('health') && str_contains($request->userAgent(), 'GoogleHC')) {
-            return $response;
+        if (!$this->isGoogleHealthCheck($request)) {
+            app(UserActivityLogger::class)->info('User accessed route');
         }
-        app(UserActivityLogger::class)->info('User accessed route');
         return $response;
+    }
+
+    /**
+    * Determine if the request is a Google Cloud health check.
+    *
+    * @param  Request  $request  The incoming HTTP request.
+    * @return bool  True if it's a Google health check, false otherwise.
+    */
+    private function isGoogleHealthCheck(Request $request): bool
+    {
+        return $request->is('health') && str_contains($request->userAgent(), 'GoogleHC');
     }
 }

--- a/app/Http/Middleware/TrustProxiesMiddleware.php
+++ b/app/Http/Middleware/TrustProxiesMiddleware.php
@@ -29,13 +29,13 @@ class TrustProxiesMiddleware extends TrustProxies
     /**
      * Create a new TrustProxiesMiddleware instance.
      *
-     * In production (when the app is behind a load balancer), trust all proxies so Laravel
+     * In demo environment (when the app is behind a load balancer), trust all proxies so Laravel
      * uses the X-Forwarded-* headers to determine the original client IP.
      *
-     * In local/dev environments, don't trust any proxies to avoid inaccurate IP detection.
+     * In local environment, don't trust any proxies to avoid inaccurate IP detection.
      */
     public function __construct()
     {
-        $this->proxies = config('app.env') === 'prod' ? '*' : null;
+        $this->proxies = config('app.env') === 'demo' ? '*' : null;
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -17,10 +17,12 @@ class AppServiceProvider extends ServiceProvider
 
     /**
      * Bootstrap any application services.
+     *
+     * Forces HTTPS in demo environment.
      */
     public function boot(): void
     {
-        if (config('app.env') === 'prod' || env('FORCE_HTTPS', false)) {
+        if (config('app.env') === 'demo' || env('FORCE_HTTPS', false)) {
             URL::forceScheme('https');
         }
     }

--- a/config/session.php
+++ b/config/session.php
@@ -43,8 +43,8 @@ return [
     'domain' => env('SESSION_DOMAIN'),
 
     // If true, cookie is sent only over HTTPS
-    // Should be true in production to prevent session hijacking
-    'secure' => env('SESSION_SECURE_COOKIE', env('APP_ENV') === 'prod'),
+    // Should be true in demo environment to prevent session hijacking
+    'secure' => env('SESSION_SECURE_COOKIE', env('APP_ENV') === 'demo'),
 
     // If true, the cookie cannot be accessed by JavaScript
     // Prevents XSS from reading session cookie

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -17,11 +17,11 @@ class UserSeeder extends Seeder
      */
     public function run(): void
     {
-        match (config('app.env')) {
-            'local' => $this->createDevUser(),
-            'demo'  => $this->createDemoUsers(),
-            default => null
-        };
+        if (config('app.env') === 'demo') {
+            $this->createDemoUsers();
+        } else {
+            $this->createDevUser();
+        }
 
         User::factory()
             ->count(config('app.num_fake_users', 10))

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -10,7 +10,7 @@ class UserSeeder extends Seeder
     /**
      * Run the database seeds.
      *
-     * Uses APP_ENV to determine whether to create prod or dev users, and
+     * Uses APP_ENV to determine whether to create demo or dev users, and
      * uses NUM_FAKE_USERS to determine how many fake users to create.
      *
      * @return void
@@ -19,7 +19,7 @@ class UserSeeder extends Seeder
     {
         match (config('app.env')) {
             'local' => $this->createDevUser(),
-            'prod'  => $this->createProdUsers(),
+            'demo'  => $this->createDemoUsers(),
             default => null
         };
 
@@ -46,11 +46,11 @@ class UserSeeder extends Seeder
     }
 
     /**
-     * Create production users with standard permissions.
+     * Create demo users with standard permissions.
      *
      * @return void
      */
-    private function createProdUsers(): void
+    private function createDemoUsers(): void
     {
         $this->createUser('gokul', env('GOKUL_USER_PASSWORD'));
         $this->createUser('grader', env('GRADER_USER_PASSWORD'));

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -32,10 +32,12 @@
         </div>
 
         <!-- Register Button -->
-        <div class="flex items-center justify-center mt-4">
-            <a href="{{ route('register') }}" class="inline-flex items-center px-4 py-2 bg-gray-200 dark:bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-gray-700 dark:text-gray-300 uppercase tracking-widest hover:bg-gray-300 dark:hover:bg-gray-700 focus:outline-none focus:border-gray-300 dark:focus:border-gray-600 focus:ring ring-gray-300 dark:ring-gray-600">
-                {{ __('Create an Account') }}
-            </a>
-        </div>
+        @if (config('app.env') !== 'demo')
+            <div class="flex items-center justify-center mt-4">
+                <a href="{{ route('register') }}" class="inline-flex items-center px-4 py-2 bg-gray-200 dark:bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-gray-700 dark:text-gray-300 uppercase tracking-widest hover:bg-gray-300 dark:hover:bg-gray-700 focus:outline-none focus:border-gray-300 dark:focus:border-gray-600 focus:ring ring-gray-300 dark:ring-gray-600">
+                    {{ __('Create an Account') }}
+                </a>
+            </div>
+        @endif
     </form>
 </x-guest-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,8 +19,10 @@ Route::middleware(['guest', 'login.page.limit'])->group(
         Route::get('/', fn() => redirect(route('login')));
         Route::post('/login', [AuthenticatedSessionController::class, 'login'])->name('login.attempt');
 
-        Route::get('/register', [RegisteredUserController::class, 'index'])->name('register');
-        Route::post('/register', [RegisteredUserController::class, 'register'])->name('register.attempt');
+        if (config('app.env') !== 'demo') {
+            Route::get('/register', [RegisteredUserController::class, 'index'])->name('register');
+            Route::post('/register', [RegisteredUserController::class, 'register'])->name('register.attempt');
+        }
     }
 );
 


### PR DESCRIPTION
Since we're now in the penetration testing phase, we'll probably want to have the demo deployed so we can also test in that environment. When I was going through the GCP deployment process again today, a few things came up that I wanted to change. This PR makes those changes:

- Changes the "prod" environment to "demo". I think this makes more sense since we really don't have a "production" environment. What we've been calling "prod" is really just for the demo.
- Disables the registration feature automatically in the demo environment. When we deployed before, I created a separate branch and deleted all of the stuff having to do with the registration feature. This PR makes it so we don't need to do that, and the registration link/routes are automatically disabled when the environment is 'demo'.
- Filters out Google Cloud health checks from the user activity logs. This is just to keep the logs cleaner. The health checks happen very frequently and clutter things up.
- Makes a small tweak to the user seeding logic. Instead of seeding the dev user only when env is explicitly 'local', I changed it to seed the dev user whenever the env is not 'demo'. The only difference is that the dev user is still created if the environment is set to something like 'test' (I had to do this earlier to test something, so it's not a totally contrived use-case).