### PR TITLE
Feedback Search Bug Fix

### DIFF
--- a/app/Http/Requests/FeedbackCommentRequest.php
+++ b/app/Http/Requests/FeedbackCommentRequest.php
@@ -3,6 +3,8 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Validation\ValidationException;
 
 class FeedbackCommentRequest extends FormRequest
 {
@@ -25,5 +27,16 @@ class FeedbackCommentRequest extends FormRequest
             'patient_id' => 'required|exists:patient,patient_id',
             'feedback' => 'required|string'
         ];
+    }
+
+    /**
+     * Handle a failed validation attempt.
+     */
+    protected function failedValidation(Validator $validator): void
+    {
+        throw new ValidationException(
+            $validator,
+            redirect()->route('feedback')->withErrors($validator)->withInput()
+        );
     }
 }

--- a/resources/views/components/patient-dropdown.blade.php
+++ b/resources/views/components/patient-dropdown.blade.php
@@ -17,8 +17,7 @@
            @input="showDropdown = true"
            @focus="showDropdown = true"
            class="w-full p-2 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-white" 
-           autocomplete="off" 
-           required />
+           autocomplete="off" />
     <input type="hidden" name="patient_id" x-model="selectedPatientId">
 
     @error('patient_id')

--- a/resources/views/components/patient-dropdown.blade.php
+++ b/resources/views/components/patient-dropdown.blade.php
@@ -16,8 +16,7 @@
     <input type="text" id="patient_search" x-model="search" 
            @input="showDropdown = true"
            @focus="showDropdown = true"
-           class="w-full p-2 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-white" 
-           autocomplete="off" />
+           class="w-full p-2 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-white" autocomplete="off" />
     <input type="hidden" name="patient_id" x-model="selectedPatientId">
 
     @error('patient_id')

--- a/resources/views/components/patient-dropdown.blade.php
+++ b/resources/views/components/patient-dropdown.blade.php
@@ -16,7 +16,9 @@
     <input type="text" id="patient_search" x-model="search" 
            @input="showDropdown = true"
            @focus="showDropdown = true"
-           class="w-full p-2 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-white" autocomplete="off" />
+           class="w-full p-2 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-700 text-gray-900 dark:text-white" 
+           autocomplete="off" 
+           required />
     <input type="hidden" name="patient_id" x-model="selectedPatientId">
 
     @error('patient_id')


### PR DESCRIPTION
The error `The GET method is not supported for route feedback/search. Supported methods: POST.` when you did a search on the Patient Feedback Page and then tried to submit a comment after. This issue came from the fact that, by default, if validation of the data through a validator request class fails, then it tries to send you back to where you were with a GET and the `feedback/search` route isn't setup to be accessed with a GET request.

The main way I solved this was to:

- Override the `failedValidation` method in the [`FeedbackCommentRequest`](https://github.com/BeaverHealth-Vulnerable-Web-App/BeaverHealth-Vulnerable-Web-App/pull/135/files#diff-be2ebdd0ccd20b8d00b1b531de231a0a85bcec9461b2e08e2e6cd9ca9eee6375R35) class to specify a custom redirect route when the validation fails