### PR TITLE
Make rate limiters configurable

### DIFF
--- a/app/Http/Controllers/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/AuthenticatedSessionController.php
@@ -11,6 +11,18 @@ use Illuminate\View\View;
 
 class AuthenticatedSessionController extends Controller
 {
+    private readonly bool $rateLimitEnabled;
+
+    /**
+     * Create a new controller instance and determine whether requests should be rate-limited.
+     */
+    public function __construct()
+    {
+        $env = config('app.env');
+        $enableLocalRateLimit = config('auth.login_attempts_rate_limit.enable_locally');
+        $this->rateLimitEnabled = $env === 'demo' || ($env === 'local' && $enableLocalRateLimit);
+    }
+
     /**
      * Display the login view.
      */
@@ -24,7 +36,12 @@ class AuthenticatedSessionController extends Controller
      */
     public function login(LoginRequest $request): RedirectResponse
     {
-        $request->authenticate();
+        if ($this->rateLimitEnabled) {
+            $request->authenticateOrThrottle();
+        } else {
+            $request->authenticate();
+        }
+
         $request->session()->regenerate();
         return redirect()->intended(route('dashboard', absolute: false));
     }

--- a/app/Http/Middleware/LoginPageRateLimiter.php
+++ b/app/Http/Middleware/LoginPageRateLimiter.php
@@ -111,7 +111,7 @@ class LoginPageRateLimiter
                         border-radius: 0.5rem;
                         box-shadow: 0 2px 10px rgba(0,0,0,0.2);
                         text-align: center;
-                        max-width: 24rem;
+                        max-width: 20rem;
                     }
                     .card h2 {
                         color: #f56565;

--- a/app/Http/Middleware/LoginPageRateLimiter.php
+++ b/app/Http/Middleware/LoginPageRateLimiter.php
@@ -10,6 +10,28 @@ use Symfony\Component\HttpFoundation\Response;
 
 class LoginPageRateLimiter
 {
+    // Length of the User-Agent hash prefix used in the rate limit key
+    private const USER_AGENT_HASH_LENGTH = 12;
+
+    private readonly bool $enabled;
+    private readonly int $maxAttempts;
+    private readonly int $hitDecay;
+
+    /**
+     * Creates a new LoginPageRateLimiter instance.
+     *
+     * Initializes rate limiting thresholds from configuration.
+     */
+    public function __construct()
+    {
+        $env = config('app.env');
+        $enableLocally = config('auth.login_page_access_rate_limit.enable_locally');
+
+        $this->enabled = $env === 'demo' || ($env === 'local' && $enableLocally);
+        $this->maxAttempts = config('auth.login_page_access_rate_limit.max_attempts');
+        $this->hitDecay = config('auth.login_page_access_rate_limit.decay_seconds');
+    }
+
     /**
      * Throttles repeated access to the login page based on IP address.
      *
@@ -21,18 +43,92 @@ class LoginPageRateLimiter
      */
     public function handle(Request $request, Closure $next): Response
     {
-        $key = 'login-page:' . $request->ip();
+        if ($this->enabled) {
+            $key = $this->throttleKey($request);
 
-        if (RateLimiter::tooManyAttempts($key, 10)) {
-            app(UserActivityLogger::class)->warning(
-                'Login page access blocked due to too many requests',
-                ['throttle_key' => $key]
-            );
-            return response('Too many login page requests. Please try again later.', Response::HTTP_TOO_MANY_REQUESTS);
+            if (RateLimiter::tooManyAttempts($key, $this->maxAttempts)) {
+                app(UserActivityLogger::class)->warning(
+                    'Login page access blocked due to too many requests',
+                    ['throttle_key' => $key]
+                );
+
+                $waitSeconds = RateLimiter::availableIn($key);
+
+                return $this->buildLockoutResponse($waitSeconds);
+            }
+
+            RateLimiter::hit($key, $this->hitDecay);
         }
 
-        RateLimiter::hit($key, 60);
-
         return $next($request);
+    }
+
+    /**
+     * Generate the rate-limiting key for this login attempt.
+     *
+     * @param Request $request
+     * @return string The key used for throttling (client IP + hash of User Agent)
+     */
+    private function throttleKey(Request $request): string
+    {
+        $ip = $request->ip();
+        $userAgentHash = substr(md5($request->userAgent()), 0, self::USER_AGENT_HASH_LENGTH);
+        return "login-page:{$ip}:{$userAgentHash}";
+    }
+
+    /**
+    * Build the HTTP response shown when the user is locked out due to rate limiting.
+    *
+    * @param int $waitSeconds Number of seconds remaining before the user may retry
+    * @return Response A styled HTML response with status 429.
+    */
+    private function buildLockoutResponse(int $waitSeconds): Response
+    {
+        $pluralized = $waitSeconds === 1 ? 'second' : 'seconds';
+
+        return response(
+            <<<HTML
+            <!DOCTYPE html>
+            <html lang="en">
+            <head>
+                <meta charset="UTF-8">
+                <title>Rate Limited</title>
+                <meta name="viewport" content="width=device-width, initial-scale=1">
+                <style>
+                    body {
+                        font-family: sans-serif;
+                        background-color: #1a202c;
+                        color: #e2e8f0;
+                        display: flex;
+                        justify-content: center;
+                        align-items: center;
+                        height: 100vh;
+                        margin: 0;
+                    }
+                    .card {
+                        background-color: #2d3748;
+                        padding: 2rem;
+                        border-radius: 0.5rem;
+                        box-shadow: 0 2px 10px rgba(0,0,0,0.2);
+                        text-align: center;
+                        max-width: 24rem;
+                    }
+                    .card h2 {
+                        color: #f56565;
+                        margin-bottom: 1rem;
+                    }
+                </style>
+            </head>
+            <body>
+                <div class="card">
+                    <h2>Too Many Requests</h2>
+                    <p>You’ve hit the login page too many times in a short period.</p>
+                    <p>Please try again in {$waitSeconds} {$pluralized}.</p>
+                </div>
+            </body>
+            </html>
+            HTML,
+            Response::HTTP_TOO_MANY_REQUESTS
+        );
     }
 }

--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Requests\Auth;
 
-use Illuminate\Auth\Events\Lockout;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\RateLimiter;
@@ -12,6 +11,18 @@ use App\Services\UserActivityLogger;
 
 class LoginRequest extends FormRequest
 {
+    private readonly int $rateLimitMaxAttempts;
+    private readonly int $rateLimitHitDecay;
+
+    /**
+     * Create a new LoginRequest instance and initialize rate limiting settings.
+     */
+    public function __construct()
+    {
+        $this->rateLimitMaxAttempts = config('auth.login_attempts_rate_limit.max_attempts');
+        $this->rateLimitHitDecay = config('auth.login_attempts_rate_limit.decay_seconds');
+    }
+
     /**
      * Determine if the user is authorized to make this request.
      *
@@ -36,24 +47,34 @@ class LoginRequest extends FormRequest
     }
 
     /**
-     * Attempt to authenticate the user with the given credentials.
+     * Attempt to authenticate the user without rate limiting.
      *
-     * If authentication fails or the request is rate-limited, a validation exception is thrown.
+     * @return void
+     *
+     * @throws ValidationException If authentication fails
+     */
+    public function authenticate(): void
+    {
+        if (!Auth::attempt($this->only('username', 'password'))) {
+            $this->logFailedLoginAttempt();
+            throw ValidationException::withMessages(['username' => trans('auth.failed')]);
+        }
+    }
+
+    /**
+     * Attempt to authenticate the user with rate limiting.
      *
      * @return void
      *
      * @throws ValidationException If the login fails or rate-limit is exceeded
      */
-    public function authenticate(): void
+    public function authenticateOrThrottle(): void
     {
         $this->ensureIsNotRateLimited();
 
-        if (!Auth::attempt($this->only('username', 'password'), $this->boolean('remember'))) {
-            RateLimiter::hit($this->throttleKey());
-            app(UserActivityLogger::class)->info('Failed login attempt', [
-                'attempts' => RateLimiter::attempts($this->throttleKey()),
-                'throttle_key' => $this->throttleKey(),
-            ]);
+        if (!Auth::attempt($this->only('username', 'password'))) {
+            RateLimiter::hit($this->throttleKey(), $this->rateLimitHitDecay);
+            $this->logFailedLoginAttempt();
             throw ValidationException::withMessages(['username' => trans('auth.failed')]);
         }
 
@@ -69,9 +90,9 @@ class LoginRequest extends FormRequest
      *
      * @throws ValidationException If too many attempts have been made
      */
-    protected function ensureIsNotRateLimited(): void
+    private function ensureIsNotRateLimited(): void
     {
-        if (!RateLimiter::tooManyAttempts($this->throttleKey(), 5)) {
+        if (!RateLimiter::tooManyAttempts($this->throttleKey(), $this->rateLimitMaxAttempts)) {
             return;
         }
 
@@ -80,19 +101,17 @@ class LoginRequest extends FormRequest
             ['throttle_key' => $this->throttleKey()]
         );
 
-        event(new Lockout($this));
-
         $seconds = RateLimiter::availableIn($this->throttleKey());
 
         throw ValidationException::withMessages(
             [
-            'username' => trans(
-                'auth.throttle',
-                [
-                    'seconds' => $seconds,
-                    'minutes' => ceil($seconds / 60),
-                ]
-            ),
+                'username' => trans(
+                    'auth.throttle',
+                    [
+                        'seconds' => $seconds,
+                        'minutes' => ceil($seconds / 60),
+                    ]
+                ),
             ]
         );
     }
@@ -102,8 +121,21 @@ class LoginRequest extends FormRequest
      *
      * @return string The key used for throttling (username + client IP)
      */
-    protected function throttleKey(): string
+    private function throttleKey(): string
     {
         return Str::lower($this->string('username') . '|' . $this->ip());
+    }
+
+    /**
+     * Log a failed login attempt for the current throttle key.
+     */
+    private function logFailedLoginAttempt(): void
+    {
+        $key = $this->throttleKey();
+
+        app(UserActivityLogger::class)->info('Failed login attempt', [
+            'attempts' => RateLimiter::attempts($key),
+            'throttle_key' => $key,
+        ]);
     }
 }

--- a/config/auth.php
+++ b/config/auth.php
@@ -23,4 +23,28 @@ return [
         ],
     ],
 
+    // Rate limiting for login page accesses
+    'login_page_access_rate_limit' => [
+        // Whether to enable rate limiting for login page accesses locally
+        'enable_locally' => env('LOGIN_PAGE_ACCESS_RATE_ENABLE', false),
+
+        // The number of accesses before a lockout occurs
+        'max_attempts' => env('LOGIN_PAGE_ACCESS_RATE_MAX', 15),
+
+        // How long before a recorded access expires and no longer counts toward the limit
+        'decay_seconds' => env('LOGIN_PAGE_ACCESS_RATE_DECAY', 60),
+    ],
+
+    // Rate limiting for login attempts
+    'login_attempts_rate_limit' => [
+        // Whether to enable rate limiting for login attempts locally
+        'enable_locally' => env('LOGIN_ATTEMPTS_RATE_ENABLE', false),
+
+        // The number of login attempts before a lockout occurs
+        'max_attempts' => env('LOGIN_ATTEMPTS_RATE_MAX', 5),
+
+        // How long before a failed login attempt expires and no longer counts toward the limit
+        'decay_seconds' => env('LOGIN_ATTEMPTS_RATE_DECAY', 60),
+    ]
+
 ];

--- a/tests/Feature/AuthFeatureTest.php
+++ b/tests/Feature/AuthFeatureTest.php
@@ -4,7 +4,8 @@ namespace Tests\Feature;
 
 use Tests\TestCase;
 use App\Models\User;
-use Illuminate\Testing\TestResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Support\Facades\Config;
 
 class AuthFeatureTest extends TestCase
 {
@@ -13,7 +14,6 @@ class AuthFeatureTest extends TestCase
     private const TEST_PASSWORD = 'password123';
     private const TEST_WEAK_PASSWORD = '123';
     private const TEST_WRONG_PASSWORD = 'wrongpassword';
-    private const MAX_LOGIN_ATTEMPTS = 5;
 
     private function createTestUser(): User
     {
@@ -23,19 +23,6 @@ class AuthFeatureTest extends TestCase
                 'password' => bcrypt(self::TEST_PASSWORD),
             ]
         );
-    }
-
-    private function triggerLoginLockout(): void
-    {
-        for ($i = 0; $i < self::MAX_LOGIN_ATTEMPTS; $i++) {
-            $this->postWithCsrf(
-                route('login.attempt'),
-                [
-                    'username' => self::TEST_USERNAME,
-                    'password' => self::TEST_WRONG_PASSWORD,
-                ]
-            );
-        }
     }
 
     public function testGuestIsRedirectedFromDashboard(): void
@@ -277,29 +264,120 @@ class AuthFeatureTest extends TestCase
         $this->assertAuthenticatedAs($user);
     }
 
-    public function testLoginLockoutAfterFailedAttempts(): void
+    public function testDemoEnvRateLimitsLoginAttempts(): void
     {
+        Config::set('app.env', 'demo');
+        Config::set('auth.login_attempts_rate_limit.max_attempts', 1);
         $this->createTestUser();
+        $this->get(route('login'));
 
-        $this->get(route('login'))
-            ->assertOk();
+        $this->postWithCsrf(route('login.attempt'), [
+            'username' => self::TEST_USERNAME,
+            'password' => 'wrong',
+        ]);
 
-        $this->triggerLoginLockout();
+        $errors = session('errors')->getBag('default')->get('username');
+        $this->assertCount(1, $errors);
+        $this->assertSame('These credentials do not match our records.', $errors[0]);
 
-        $response = $this->postWithCsrf(
-            route('login.attempt'),
-            [
-                'username' => self::TEST_USERNAME,
-                'password' => self::TEST_WRONG_PASSWORD,
-            ]
-        )->assertFound();
+        $this->postWithCsrf(route('login.attempt'), [
+            'username' => self::TEST_USERNAME,
+            'password' => 'wrong',
+        ]);
 
-        $errors = (new TestResponse($response)) // TestResponse needed to access session errors
-            ->session()
-            ->get('errors')
-            ->getBag('default')
-            ->get('username');
-
+        $errors = session('errors')->getBag('default')->get('username');
+        $this->assertCount(1, $errors);
         $this->assertStringContainsString('Too many login attempts', $errors[0]);
+    }
+
+    public function testLocalEnvNoRateLimitWhenDisabled(): void
+    {
+        Config::set('app.env', 'local');
+        Config::set('auth.login_attempts_rate_limit.enable_locally', false);
+        Config::set('auth.login_attempts_rate_limit.max_attempts', 1);
+
+        $this->createTestUser();
+        $this->get(route('login'));
+
+        $this->postWithCsrf(route('login.attempt'), [
+            'username' => self::TEST_USERNAME,
+            'password' => 'wrong',
+        ]);
+
+        $errors = session('errors')->getBag('default')->get('username');
+        $this->assertCount(1, $errors);
+        $this->assertSame('These credentials do not match our records.', $errors[0]);
+
+        $this->postWithCsrf(route('login.attempt'), [
+            'username' => self::TEST_USERNAME,
+            'password' => 'wrong',
+        ]);
+
+        $errors = session('errors')->getBag('default')->get('username');
+        $this->assertCount(1, $errors);
+        $this->assertSame('These credentials do not match our records.', $errors[0]);
+    }
+
+    public function testLocalEnvRateLimitsLoginWhenEnabled(): void
+    {
+        Config::set('app.env', 'local');
+        Config::set('auth.login_attempts_rate_limit.enable_locally', true);
+        Config::set('auth.login_attempts_rate_limit.max_attempts', 1);
+
+        $this->createTestUser();
+        $this->get(route('login'));
+
+        $this->postWithCsrf(route('login.attempt'), [
+            'username' => self::TEST_USERNAME,
+            'password' => 'wrong',
+        ]);
+
+        $errors = session('errors')->getBag('default')->get('username');
+        $this->assertCount(1, $errors);
+        $this->assertSame('These credentials do not match our records.', $errors[0]);
+
+        $this->postWithCsrf(route('login.attempt'), [
+            'username' => self::TEST_USERNAME,
+            'password' => 'wrong',
+        ]);
+
+        $errors = session('errors')->getBag('default')->get('username');
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString('Too many login attempts', $errors[0]);
+    }
+
+    public function testDemoEnvRateLimitsLoginPageAccess(): void
+    {
+        Config::set('app.env', 'demo');
+        Config::set('auth.login_page_access_rate_limit.max_attempts', 1);
+
+        $this->get(route('login'), ['User-Agent' => 'TestAgent1'])->assertOk();
+
+        $this->get(route('login'), ['User-Agent' => 'TestAgent1'])
+        ->assertStatus(Response::HTTP_TOO_MANY_REQUESTS)
+        ->assertSeeText('Too Many Requests');
+    }
+
+    public function testLocalEnvNoLoginPageRateLimitWhenDisabled(): void
+    {
+        Config::set('app.env', 'local');
+        Config::set('auth.login_page_access_rate_limit.enable_locally', false);
+        Config::set('auth.login_page_access_rate_limit.max_attempts', 1);
+
+        $this->get(route('login'), ['User-Agent' => 'TestAgent2'])->assertOk();
+        $this->get(route('login'), ['User-Agent' => 'TestAgent2'])->assertOk();
+    }
+
+    public function testLocalEnvRateLimitsLoginPageWhenEnabled(): void
+    {
+        Config::set('app.env', 'local');
+        Config::set('auth.login_page_access_rate_limit.enable_locally', true);
+        Config::set('auth.login_page_access_rate_limit.max_attempts', 1);
+
+        $this->get(route('login'), ['User-Agent' => 'TestAgent3'])->assertOk();
+
+        $this->get(route('login'), ['User-Agent' => 'TestAgent3'])
+        ->assertStatus(Response::HTTP_TOO_MANY_REQUESTS)
+        ->assertSeeText('Too Many Requests');
     }
 }


### PR DESCRIPTION
In our last meeting we decided to disable rate limiting for login page accesses locally. I took this a little farther and made it so:
- Both the login page access rate limiter and the login attempt rate limiter are configurable in the `local` environment
  - By default, both are disabled locally
  - They can be enabled by setting environment variables `LOGIN_PAGE_ACCESS_RATE_ENABLE` and `LOGIN_ATTEMPTS_RATE_ENABLE`, or by editing the default values in `config/auth.php`
- Both rate limiters are still always enabled in the `demo` environment
- Also made max attempts and hit decay rate configurable for both rate limiters. These can be configured regardless of environment

While I was at it, I also:
- Added inline HTML and styling to the lockout response, so the lockout view now looks nicer and shows the time remaining, but uses less resources than rendering a Blade template.
- Added tests to make sure the configuration logic works as expected
- Added a hash of the client's user agent to the key for the login page access rate limiter. In current `master`, it only uses the IP, which I think could potentially be a problem for people with the same IP. For example, if multiple people were on the same VPN or local network and had the same IP, and one person triggers the lockout, it would lock everybody with that IP out. Including the user agent in the key is just a way to prevent that. It's not foolproof, but I haven't been able to find a perfect solution. I think a better solution would probably be to add a captcha, but that would require more development effort, and I think this works well enough, especially since it only matters for the demo.