### PR TITLE
Fix logout force browse bug

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -40,6 +41,19 @@ return Application::configure(basePath: dirname(__DIR__))
                         return redirect()->route('dashboard');
                     } else {
                         $logger->warning('Guest accessed unregistered route');
+                        return redirect()->route('login');
+                    }
+                }
+            );
+
+            $exceptions->renderable(
+                function (MethodNotAllowedHttpException $e) {
+                    $logger = app(UserActivityLogger::class);
+                    if (Auth::check()) {
+                        $logger->info("User accessed route with wrong HTTP method");
+                        return redirect()->route('dashboard');
+                    } else {
+                        $logger->info("Guest accessed route with wrong HTTP method");
                         return redirect()->route('login');
                     }
                 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -36,26 +36,16 @@ return Application::configure(basePath: dirname(__DIR__))
             $exceptions->renderable(
                 function (NotFoundHttpException $e) {
                     $logger = app(UserActivityLogger::class);
-                    if (Auth::check()) {
-                        $logger->info('User accessed unregistered route');
-                        return redirect()->route('dashboard');
-                    } else {
-                        $logger->warning('Guest accessed unregistered route');
-                        return redirect()->route('login');
-                    }
+                    $logger->info('Unregistered route access');
+                    return redirect()->route('login');
                 }
             );
 
             $exceptions->renderable(
                 function (MethodNotAllowedHttpException $e) {
                     $logger = app(UserActivityLogger::class);
-                    if (Auth::check()) {
-                        $logger->info("User accessed route with wrong HTTP method");
-                        return redirect()->route('dashboard');
-                    } else {
-                        $logger->info("Guest accessed route with wrong HTTP method");
-                        return redirect()->route('login');
-                    }
+                    $logger->info('Registered route accessed with wrong HTTP method');
+                    return redirect()->route('login');
                 }
             );
         }


### PR DESCRIPTION
This PR fixes the bug that Sean found where you get a `MethodNotAllowedHttpException` when navigating directly to `/logout`.

It should actually fix any case where the wrong HTTP method is used for any registered route. It does this by adding an app-wide exception handler for `MethodNotAllowedHttpException`.

We already have handling for `NotFoundHttpException`, so we should now be covered for all cases where a user either tries to access an unregistered route, or tries to use the wrong HTTP method for a registered route.