### PR TITLE
Add pagination to Patient Feedback page

### DIFF
--- a/app/Http/Controllers/FeedbackController.php
+++ b/app/Http/Controllers/FeedbackController.php
@@ -36,6 +36,11 @@ class FeedbackController extends Controller
     public function search(FeedbackSearchRequest $request)
     {
         $searchResults = $this->feedbackService->searchFeedback($request);
-        return view('feedback.index', $searchResults[0])->with('search_name', $searchResults[1]);
+        $searchName = $searchResults[1];
+
+        // Append search parameter to pagination links
+        $searchResults[0]['feedback']->appends(['search_name' => $searchName]);
+
+        return view('feedback.index', $searchResults[0])->with('search_name', $searchName);
     }
 }

--- a/app/Services/FeedbackService.php
+++ b/app/Services/FeedbackService.php
@@ -8,6 +8,7 @@ use App\Models\Patient;
 use App\Models\PatientFeedback;
 use App\Services\UserActivityLogger;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Pagination\LengthAwarePaginator;
 
 class FeedbackService
 {
@@ -20,7 +21,7 @@ class FeedbackService
         return $useRaw ? $userInput : e($userInput);
     }
 
-    private function sanitizeStoredFeedback(Collection &$feedback): void
+    private function sanitizeStoredFeedback(Collection|LengthAwarePaginator $feedback): void
     {
         foreach ($feedback as $item) {
             if ($item->is_vulnerable) {
@@ -31,10 +32,12 @@ class FeedbackService
 
     public function getFeedbackWithPatients()
     {
-        $feedback = PatientFeedback::orderBy('created_at', 'desc')->get();
+        $feedback = PatientFeedback::orderBy('created_at', 'desc')->paginate(10);
+
         if (!auth()->user()->xss_stored_on) {
             $this->sanitizeStoredFeedback($feedback);
         }
+
         return ['feedback' => $feedback, 'patients' => Patient::all()];
     }
 
@@ -74,8 +77,10 @@ class FeedbackService
         $feedback = PatientFeedback::whereHas('patient', function ($query) use ($processedSearchTerm) {
             $query->where('first_name', 'like', "%{$processedSearchTerm}%")
                 ->orWhere('last_name', 'like', "%{$processedSearchTerm}%");
-        })->orderBy('created_at', 'desc')->get();
+        })->orderBy('created_at', 'desc')->paginate(10);
+
         $this->sanitizeStoredFeedback($feedback); // Sanitized so that it doesn't interfere with the Reflective XSS
+
         return [['feedback' => $feedback, 'patients' => Patient::all()], $processedSearchTerm];
     }
 }

--- a/resources/views/feedback/index.blade.php
+++ b/resources/views/feedback/index.blade.php
@@ -39,8 +39,13 @@
                         <form action="{{ route('feedback.search') }}" method="GET">
                             <div class="mb-4">
                                 <label for="search_name" class="block mb-2 font-semibold">Search by Name</label>
-                                <input type="text" class="w-full p-2 border border-gray-300 rounded text-base mb-4 dark:text-white dark:bg-gray-900 dark:border-gray-600"
-                                    id="search_name" name="search_name" value="{{ $search_name ?? '' }}" required>
+                                <input type="text"
+                                    class="w-full p-2 border border-gray-300 rounded text-base mb-4 dark:text-white dark:bg-gray-900 dark:border-gray-600"
+                                    id="search_name"
+                                    name="search_name"
+                                    value="{{ $search_name ?? '' }}"
+                                    maxlength="255"
+                                    required>
                             </div>
                             <button type="submit" class="w-full md:w-auto px-6 py-4 bg-gray-500 text-white font-medium text-sm leading-tight uppercase rounded shadow-md hover:bg-gray-600 hover:shadow-lg focus:bg-gray-600 focus:shadow-lg focus:outline-none focus:ring-0 active:bg-gray-700 active:shadow-lg transition duration-150 ease-in-out dark:bg-gray-700 dark:hover:bg-gray-600">
                                 Search

--- a/resources/views/feedback/index.blade.php
+++ b/resources/views/feedback/index.blade.php
@@ -83,7 +83,7 @@
                                 {{ $comment->patient->first_name }} {{ $comment->patient->last_name }}
                             @endif
                         </h5>
-                        <p class="text-gray-700 dark:text-gray-300" style="word-break: break-all; overflow-wrap: anywhere; max-width: 100%; hyphens: auto;">
+                        <p class="text-gray-700 dark:text-gray-300 break-words overflow-x-auto max-w-full">
                             {!! $comment->feedback !!}
                         </p>
                         <br>

--- a/resources/views/feedback/index.blade.php
+++ b/resources/views/feedback/index.blade.php
@@ -81,12 +81,22 @@
                     <small class="text-gray-600 dark:text-gray-400">Posted on: {{ $comment->created_at->format('M d, Y H:i') }}</small>
                 </div>
                 @endforeach
+
+                <!-- Pagination Links -->
+                <div class="mt-6">
+                    @if(isset($search_name))
+                        {{ $feedback->appends(['search_name' => $search_name])->links() }}
+                    @else
+                        {{ $feedback->links() }}
+                    @endif
+                </div>
+
                 @else
                 <p>No comments found.</p>
                 @endif
             </div>
         </div>
-    </div>
+
     <!-- Status message -->
     @if(session('feedback-status'))
         <x-status-message

--- a/resources/views/feedback/index.blade.php
+++ b/resources/views/feedback/index.blade.php
@@ -36,11 +36,11 @@
                         Search Comments
                     </div>
                     <div class="p-4">
-                        <form action="{{ route('feedback.search') }}" method="POST">
-                            @csrf
+                        <form action="{{ route('feedback.search') }}" method="GET">
                             <div class="mb-4">
                                 <label for="search_name" class="block mb-2 font-semibold">Search by Name</label>
-                                <input type="text" class="w-full p-2 border border-gray-300 rounded text-base mb-4 dark:text-white dark:bg-gray-900 dark:border-gray-600" id="search_name" name="search_name" required>
+                                <input type="text" class="w-full p-2 border border-gray-300 rounded text-base mb-4 dark:text-white dark:bg-gray-900 dark:border-gray-600"
+                                    id="search_name" name="search_name" value="{{ $search_name ?? '' }}" required>
                             </div>
                             <button type="submit" class="w-full md:w-auto px-6 py-4 bg-gray-500 text-white font-medium text-sm leading-tight uppercase rounded shadow-md hover:bg-gray-600 hover:shadow-lg focus:bg-gray-600 focus:shadow-lg focus:outline-none focus:ring-0 active:bg-gray-700 active:shadow-lg transition duration-150 ease-in-out dark:bg-gray-700 dark:hover:bg-gray-600">
                                 Search

--- a/resources/views/feedback/index.blade.php
+++ b/resources/views/feedback/index.blade.php
@@ -78,7 +78,7 @@
                                 {{ $comment->patient->first_name }} {{ $comment->patient->last_name }}
                             @endif
                         </h5>
-                        <p class="text-gray-700 dark:text-gray-300" style="word-break: break-all; overflow-wrap: anywhere; white-space: pre-wrap; max-width: 100%; hyphens: auto;">
+                        <p class="text-gray-700 dark:text-gray-300" style="word-break: break-all; overflow-wrap: anywhere; max-width: 100%; hyphens: auto;">
                             {!! $comment->feedback !!}
                         </p>
                         <br>

--- a/resources/views/feedback/index.blade.php
+++ b/resources/views/feedback/index.blade.php
@@ -52,14 +52,16 @@
         </div>
 
         @if(isset($search_name))
-        <div class="text-center mt-8 mb-8">
-            <h4 class="dark:text-white text-gray-800">Showing results for: {!! $search_name !!}</h4>
-        </div>
-        <div class="text-center mt-8 mb-8">
-            <a href="{{ route('feedback') }}" class="w-full md:w-auto px-6 py-4 bg-gray-500 text-white font-medium text-sm leading-tight uppercase rounded shadow-md hover:bg-gray-600 hover:shadow-lg focus:bg-gray-600 focus:shadow-lg focus:outline-none focus:ring-0 active:bg-gray-700 active:shadow-lg transition duration-150 ease-in-out dark:bg-gray-700 dark:hover:bg-gray-600">
-                See All Posts
-            </a>
-        </div>
+            <div class="text-center mt-8 mb-8">
+                <h4 class="dark:text-white text-gray-800">
+                    Showing results for: {!! $search_name !!}
+                </h4>
+            </div>
+            <div class="text-center mt-8 mb-8">
+                <a href="{{ route('feedback') }}" class="w-full md:w-auto px-6 py-4 bg-gray-500 text-white font-medium text-sm leading-tight uppercase rounded shadow-md hover:bg-gray-600 hover:shadow-lg focus:bg-gray-600 focus:shadow-lg focus:outline-none focus:ring-0 active:bg-gray-700 active:shadow-lg transition duration-150 ease-in-out dark:bg-gray-700 dark:hover:bg-gray-600">
+                    See All Posts
+                </a>
+            </div>
         @endif
 
         <!-- Comments Display -->
@@ -69,17 +71,19 @@
             </div>
             <div class="p-4">
                 @if($feedback->count() > 0)
-                @foreach($feedback as $comment)
-                <div class="border-b border-gray-200 dark:border-gray-700 mb-4 pb-4">
-                    <h5 class="mb-2 text-lg font-medium dark:text-white dark:bg-gray-800">
-                        @if($comment->patient)
-                        {{ $comment->patient->first_name }} {{ $comment->patient->last_name }}
-                        @endif
-                    </h5>
-                    <p class="text-gray-700 dark:text-gray-300">{!! $comment->feedback !!}</p>
-                    <br>
-                    <small class="text-gray-600 dark:text-gray-400">Posted on: {{ $comment->created_at->format('M d, Y H:i') }}</small>
-                </div>
+                    @foreach($feedback as $comment)
+                    <div class="border-b border-gray-200 dark:border-gray-700 mb-4 pb-4">
+                        <h5 class="mb-2 text-lg font-medium dark:text-white dark:bg-gray-800">
+                            @if($comment->patient)
+                                {{ $comment->patient->first_name }} {{ $comment->patient->last_name }}
+                            @endif
+                        </h5>
+                        <p class="text-gray-700 dark:text-gray-300" style="word-break: break-all; overflow-wrap: anywhere; white-space: pre-wrap; max-width: 100%; hyphens: auto;">
+                            {!! $comment->feedback !!}
+                        </p>
+                        <br>
+                        <small class="text-gray-600 dark:text-gray-400">Posted on: {{ $comment->created_at->format('M d, Y H:i') }}</small>
+                    </div>
                 @endforeach
 
                 <!-- Pagination Links -->
@@ -92,7 +96,7 @@
                 </div>
 
                 @else
-                <p>No comments found.</p>
+                    <p>No comments found.</p>
                 @endif
             </div>
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -51,7 +51,7 @@ Route::middleware(['auth', 'check.permission'])->group(
 
         Route::get('/feedback', [FeedbackController::class, 'index'])->name('feedback');
         Route::post('/feedback/store', [FeedbackController::class, 'store'])->name('feedback.store');
-        Route::post('/feedback/search', [FeedbackController::class, 'search'])->name('feedback.search');
+        Route::get('/feedback/search', [FeedbackController::class, 'search'])->name('feedback.search');
 
         Route::get('/patients', [PatientInfoController::class, 'index'])->name('patients.index');
         Route::get('/patients/{id}', [PatientInfoController::class, 'show'])->name('patients.info');

--- a/tests/Feature/FeedbackFeatureTest.php
+++ b/tests/Feature/FeedbackFeatureTest.php
@@ -33,12 +33,7 @@ class FeedbackFeatureTest extends TestCase
 
     private function sendTestSearchFeedback($name): TestResponse
     {
-        return $this->postWithCsrf(
-            route('feedback.search'),
-            [
-                'search_name' => $name
-            ]
-        );
+        return $this->get(route('feedback.search', ['search_name' => $name]));
     }
 
     public function testAuthorizedFeedbackRoute(): void
@@ -137,15 +132,6 @@ class FeedbackFeatureTest extends TestCase
         $newUser->update(['xss_stored_on' => true]);
         $this->actingAs($newUser)->get(route('feedback'))
             ->assertSee('<script>alert("hello");</script>', false);
-    }
-
-    public function testSearchingDataWithoutCsrfToken(): void
-    {
-        $this->get(route('feedback'))->assertOk();
-
-        $this->post(route('feedback.search'), [
-            'search_name' => 'FooBar'
-        ])->assertCsrfMismatch();
     }
 
     public function testSearchWithValidUsername(): void


### PR DESCRIPTION
This PR fixes basically all issues on the Patient Feedback page found during testing.

The main thing it does is add pagination to the comments list. Instead of loading all comments at once, it now loads 10 at a time. This fixes the long load times and server errors that occur when there is a large amount of comments data.

While I was doing this, I also fixed a few other issues:
- There was no wrapping when strings were really long. Updated styling to make it so long strings are wrapped.
- Changed the `/feedback/search` route to a GET method. It currently uses the POST method, which is semantically incorrect for search operations. It really should be a GET since it's reading/filtering data rather than modifying server state. This change was needed to enable proper pagination functionality, as pagination links use GET requests and were incompatible with the POST search form.
- Adds some frontend validation to prevent super long strings in the Search Comments field. Did this to fix a "Request-URI Too Long" error.